### PR TITLE
update dependencies

### DIFF
--- a/com.freerdp.FreeRDP.json
+++ b/com.freerdp.FreeRDP.json
@@ -5,10 +5,16 @@
     "sdk": "org.freedesktop.Sdk",
     "command": "sdl-freerdp",
     "cleanup": [
-        "*.la",
+        "/lib/*.a",
+        "/lib/*.la",
+        "/lib/*.so",
         "/include",
         "/lib/cmake",
-        "/lib/pkgconfig"
+        "/lib/pkgconfig",
+        "/sbin",
+        "/share/doc",
+        "/share/examples",
+        "/share/man"
     ],
     "finish-args": [
         "--share=ipc",
@@ -34,6 +40,7 @@
         }
     },
     "modules": [
+        "modules/openssl.json",
         "shared-modules/libusb/libusb.json",
         "modules/cJSON.json",
         "modules/xprop.json",

--- a/modules/opensc.json
+++ b/modules/opensc.json
@@ -8,8 +8,8 @@
       "sources": [
         {
           "type": "archive",
-          "url": "https://github.com/OpenSC/OpenSC/releases/download/0.24.0/opensc-0.24.0.tar.gz",
-          "sha256": "24d03c69287291da32a30c4c38a304ad827f56cb85d83619e1f5403ab6480ef8",
+          "url": "https://github.com/OpenSC/OpenSC/releases/download/0.25.0/opensc-0.25.0.tar.gz",
+          "sha256": "e6d7b66e2a508a377ac9d67aa463025d3c54277227be10bd08872e3407d6622f",
           "x-checker-data": {
               "type": "anitya",
               "project-id": 13287,

--- a/modules/openssl.json
+++ b/modules/openssl.json
@@ -1,0 +1,17 @@
+{
+	"name": "openssl",
+	"buildsystem": "simple",
+	"build-commands": [
+		"./config --prefix=/app --openssldir=/app --libdir=lib shared",
+		"make -j build_sw",
+		"make -j install_sw"
+	],
+	"cleanup": [],
+	"sources": [
+		{
+			"type": "archive",
+			"url": "https://openssl.org/source/openssl-3.1.5.tar.gz",
+			"sha256": "6ae015467dabf0469b139ada93319327be24b98251ffaeceda0221848dc09262"
+		}
+	]
+}

--- a/modules/pcsc.json
+++ b/modules/pcsc.json
@@ -12,8 +12,8 @@
         {
            "type": "git",
            "url": "https://github.com/LudovicRousseau/PCSC.git",
-           "tag": "2.0.1",
-           "commit": "932d77d7c93c39d8308451497425db1962f53b55",
+           "tag": "2.0.3",
+           "commit": "c4e7f6f9c6fe56fafd3f13c31fcc4f670ad6d022",
            "x-checker-data": {
                "type": "anitya",
                "project-id": 2611,


### PR DESCRIPTION
* update dependencies to most recent version
* start shipping openssl 3.1.5 as we require legacy providers