### PR TITLE
update to 3.10.3

### DIFF
--- a/com.freerdp.FreeRDP.appdata.xml
+++ b/com.freerdp.FreeRDP.appdata.xml
@@ -46,6 +46,9 @@
   </provides>
 
   <releases>
+    <release version="3.10.3" type="stable" urgency="medium" date="2025-12-17">
+      <url>https://github.com/FreeRDP/FreeRDP/releases/tag/3.10.3</url>
+    </release>
     <release version="3.10.2" type="stable" urgency="medium" date="2024-12-16">
       <url>https://github.com/FreeRDP/FreeRDP/releases/tag/3.10.2</url>
     </release>

--- a/com.freerdp.FreeRDP.json
+++ b/com.freerdp.FreeRDP.json
@@ -3,7 +3,7 @@
     "runtime": "org.freedesktop.Platform",
     "runtime-version": "24.08",
     "sdk": "org.freedesktop.Sdk",
-    "command": "sdl-freerdp",
+    "command": "freerdp-run.sh",
     "cleanup": [
         "/lib/*.a",
         "/lib/*.la",
@@ -74,8 +74,12 @@
                 "-DWITH_SSE2:BOOL=ON",
                 "-DWITH_NEON:BOOL=ON",
                 "-DWITH_FFMPEG:BOOL=ON",
+                "-DWITH_VERBOSE_WINPR_ASSERT:BOOL=OFF",
                 "-DWITH_DSP_FFMPEG:BOOL=ON",
                 "-DWITH_FAAC:BOOL=OFF",
+                "-DWITH_INTERNAL_MD4:BOOL=ON",
+                "-DWITH_INTERNAL_MD5:BOOL=ON",
+                "-DWITH_INTERNAL_RC4:BOOL=ON",
                 "-DWINPR_UTILS_IMAGE_PNG:BOOL=ON",
                 "-DWINPR_UTILS_IMAGE_WEBP:BOOL=ON",
                 "-DWINPR_UTILS_IMAGE_JPEG:BOOL=ON",
@@ -89,8 +93,8 @@
                 {
                     "type": "git",
                     "url": "https://github.com/FreeRDP/FreeRDP.git",
-                    "tag": "3.10.2",
-                    "commit": "ea2a3ee1b6ee622171669df3814aeca70a496c31",
+                    "tag": "3.10.3",
+                    "commit": "1f168a62db864f7b676964ca3f399ec76a4ae91c",
                     "x-checker-data": {
                         "type": "anitya",
                         "project-id": 10442,
@@ -106,6 +110,8 @@
             "build-commands": [
                 "install -D com.freerdp.FreeRDP.desktop $FLATPAK_DEST/share/applications/com.freerdp.FreeRDP.desktop",
                 "install -D com.freerdp.FreeRDP.appdata.xml $FLATPAK_DEST/share/appdata/com.freerdp.FreeRDP.appdata.xml",
+                "install -D legacy-openssl.cnf $FLATPAK_DEST/share/legacy-openssl.cnf",
+                "install -D freerdp-run.sh $FLATPAK_DEST/bin/freerdp-run.sh",
                 "mkdir -p $FLATPAK_DEST/lib/openh264",
                 "mkdir -p $FLATPAK_DEST/lib/ffmpeg",
                 "install -D FreeRDP_Logo_Icon.svg $FLATPAK_DEST/share/icons/hicolor/scalable/apps/FreeRDP_Icon.svg",

--- a/freerdp-run.sh
+++ b/freerdp-run.sh
@@ -1,0 +1,3 @@
+#!/bin/bash -xe
+export OPENSSL_CONF=/app/share/legacy-openssl.cnf
+/app/bin/sdl-freerdp $@

--- a/legacy-openssl.cnf
+++ b/legacy-openssl.cnf
@@ -1,0 +1,12 @@
+[openssl_init]
+providers = provider_sect
+
+[provider_sect]
+default = default_sect
+legacy = legacy_sect
+
+[default_sect]
+activate = 1
+
+[legacy_sect]
+activate = 1

--- a/modules/SDL2_image.json
+++ b/modules/SDL2_image.json
@@ -11,7 +11,7 @@
         {
             "type": "archive",
             "url": "https://github.com/libsdl-org/SDL_image/releases/download/release-2.8.4/SDL2_image-2.8.4.tar.gz",
-            "sha256": "5a89a01420a192b89dbcc5f5267448181d5dcc81d2f5a1688cb1eac6f557da67",
+            "sha256": "f7c06a8783952cfe960adccdd3d8472b63ab31475b4390d10cfdcc1aea61238f",
             "x-checker-data": {
                 "type": "anitya",
                 "project-id": 4781,


### PR DESCRIPTION
* Use FreeRDP 3.10.3
* Fix OpenSSL legacy cipher configuration
* Update FreeRDP build settings, disable WITH_VERBOSE_WINPR_ASSERT, enable internal MD4, MD5 and RC4 replacements