### PR TITLE
Enable RDPECAM client in flatpak release

### DIFF
--- a/com.freerdp.FreeRDP.json
+++ b/com.freerdp.FreeRDP.json
@@ -64,6 +64,7 @@
                 "-DCMAKE_INSTALL_LIBDIR:PATH=lib",
                 "-DCHANNEL_TSMF:BOOL=OFF",
                 "-DCHANNEL_URBDRC:BOOL=ON",
+				"-DCHANNEL_RDPECAM_CLIENT:BOOL=ON",
                 "-DBUILD_TESTING:BOOL=OFF",
                 "-DWITH_MANPAGES:BOOL=OFF",
                 "-DWITH_WAYLAND:BOOL=ON",


### PR DESCRIPTION
Adds necessary configuration to enable RDPECAM client webcam redirection support.